### PR TITLE
try test to add image to docs

### DIFF
--- a/01-intro.Rmd
+++ b/01-intro.Rmd
@@ -6,6 +6,14 @@ ottrpal::set_knitr_image_path()
 
 
 # Introduction
+<div class="img-wrap" style="max-width:320px;margin:0 auto;">
+  <img
+    src="https://hutchdatascience.org/daseh_instructor_guide/assets/leaf.png"
+    alt="Leaf"
+    loading="lazy"
+    style="width:10%;height:auto;display:block;"
+    onerror="this.onerror=null;this.src='https://raw.githubusercontent.com/fhdsl/daseh_instructor_guide/1afbe6783430718ae6a63c607da6e457a73a90ff/assets/leaf.png';">
+</div>
 ***
 
 


### PR DESCRIPTION
I have a theory that the way the action is set up, unless in image is used directly by the bookdown rmd files (as opposed to by the css file) then it might not get moved to the docs/assets directory for example - this appears to be the case - here is a test to try to add a file to that dir